### PR TITLE
TLUNIZIN-755

### DIFF
--- a/SIS_import/sis_set_url.rb
+++ b/SIS_import/sis_set_url.rb
@@ -190,7 +190,7 @@ def get_all_canvas_page_urls(response_headers)
 		# start from the second page, since we already have result of the first page
 		for page_num in 2 .. last_page_number
 			# copy the last page url params, but replace it with
-			page_url = page_url_part_one.concat(page_num.to_s).concat(page_url_part_two)
+			page_url = page_url_part_one + page_num.to_s + page_url_part_two
 			page_url_ary.push(page_url)
 		end
 	end


### PR DESCRIPTION
 previously .concat function was used to construct paged Canvas calls. However, the .concat changes the calling object, so that the resulting URL was not formed correctly