### PR TITLE
checkin Gemfile.lock to make sure same version of gems are installell for later deployments

### DIFF
--- a/SIS_import/Gemfile.lock
+++ b/SIS_import/Gemfile.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    execjs (2.7.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    libv8 (3.16.14.19-x86_64-darwin-17)
+    mime-types (3.3)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
+    mini_portile2 (2.4.0)
+    netrc (0.11.0)
+    nokogiri (1.10.5)
+      mini_portile2 (~> 2.4.0)
+    public_suffix (4.0.1)
+    ref (2.0.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rubyzip (1.3.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
+    uglifier (4.2.0)
+      execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
+    zip-zip (0.3)
+      rubyzip (>= 1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  addressable
+  execjs
+  nokogiri
+  rest-client
+  rubyzip (~> 1.3.0)
+  therubyracer
+  uglifier
+  zip-zip
+
+BUNDLED WITH
+   1.17.2


### PR DESCRIPTION
This is according to the discussion with Jeff: we think it is better to check in Gemfile.lock into Github, so that we can ensure the same version of packages are used for later deployment:

https://bundler.io/v1.17/rationale.html
https://bundler.io/v1.17/guides/bundler_sharing.html

